### PR TITLE
feat: add simulate transaction before execution and print error messa…

### DIFF
--- a/src/components/account/selectedAccount.tsx
+++ b/src/components/account/selectedAccount.tsx
@@ -210,22 +210,26 @@ export const SelectedAccountInfo: React.FC<{ handleBack: () => void }> = ({
                 whiteSpace={"pre-wrap"}
                 sx={{
                   wordBreak: "break-word",
+                  color: transactionData.error ? 'red' : 'inherit',
                 }}
               >
-                {JSON.stringify(transactionData, null, 2)}
+                {transactionData.error
+                ? JSON.stringify(transactionData.error, null, 2)
+                : JSON.stringify(transactionData.data, null, 2)}
               </Box>
               <Stack justifyContent={"center"} direction={"row"} spacing={3}>
                 <Button
                   variant="outlined"
                   color="primary"
-                  onClick={() => handleConfirm(transactionData)}
+                  onClick={() => handleConfirm(transactionData.data)}
+                  disabled={!!transactionData.error}
                 >
                   Confirm
                 </Button>
                 <Button
                   variant="outlined"
                   color="secondary"
-                  onClick={() => handleDecline(transactionData)}
+                  onClick={() => handleDecline(transactionData.data)}
                 >
                   Decline
                 </Button>

--- a/src/components/context/context.tsx
+++ b/src/components/context/context.tsx
@@ -35,6 +35,11 @@ export interface Options {
     requestBodySizeLimit: number,
 }
 
+export interface TransactionInfo {
+  data: any,
+  error?: any
+}
+
 interface MyContextValue {
     accounts: AccountData[];
     setAccounts: React.Dispatch<React.SetStateAction<AccountData[]>>;
@@ -54,8 +59,8 @@ interface MyContextValue {
     setUrlList: React.Dispatch<React.SetStateAction<ListOfDevnet[]>>;
     selectedComponent: Component | null;
     setSelectedComponent: React.Dispatch<React.SetStateAction<Component | null>>;
-    transactionData: any;
-    setTransactionData: React.Dispatch<React.SetStateAction<any>>;
+    transactionData: TransactionInfo | null;
+    setTransactionData: React.Dispatch<React.SetStateAction<TransactionInfo | null>>;
     signatureData: any;
     setSignatureData: React.Dispatch<React.SetStateAction<any>>;
   }

--- a/src/components/contractInteraction/messageActions.ts
+++ b/src/components/contractInteraction/messageActions.ts
@@ -22,11 +22,15 @@ export type PreAuthorisationMessage =
   | {
       type: "EXECUTE_RIVET_TRANSACTION"
       data: ExecuteTransactionRequest
+      error?: any
     }
   | { type: "EXECUTE_RIVET_TRANSACTION_RES"; data: any }
   | {
-      type: "RIVET_TRANSACTION_SUBMITTED"
-      data: { txHash: string; actionHash: string }
+      type: "SIMULATE_RIVET_TRANSACTION"
+      data: ExecuteTransactionRequest
+    }
+  | {
+      type: "SIMULATE_RIVET_TRANSACTION_RES"; data: any
     }
   | {
       type: "RIVET_TRANSACTION_FAILED"

--- a/src/components/contractInteraction/rivetAccount.ts
+++ b/src/components/contractInteraction/rivetAccount.ts
@@ -29,6 +29,20 @@ import {
         abis?: Abi[] | UniversalDetails,
         transactionsDetail?: UniversalDetails
     ): Promise<InvokeFunctionResponse> {
+
+        sendMessage({
+            type: "SIMULATE_RIVET_TRANSACTION",
+            data: {
+            transactions,
+            abis,
+            transactionsDetail,
+            },
+        })
+
+        const responseSimulate = await Promise.race([
+          waitForMessage("SIMULATE_RIVET_TRANSACTION_RES", 10 * 60 * 1000),
+        ])
+
         sendMessage({
             type: "EXECUTE_RIVET_TRANSACTION",
             data: {
@@ -36,6 +50,7 @@ import {
             abis,
             transactionsDetail,
             },
+            error: responseSimulate?.error
         })
 
         const response = await Promise.race([

--- a/src/contentScript/index.ts
+++ b/src/contentScript/index.ts
@@ -59,13 +59,14 @@ window.addEventListener('message', async function(event) {
         console.error("Unexpected error:", error);
       }
     } else if (event.data.type === 'EXECUTE_RIVET_TRANSACTION') {
-      let res = await chrome.runtime.sendMessage({ type: "EXECUTE_RIVET_TRANSACTION", data: event.data.data });
+      let res = await chrome.runtime.sendMessage({ type: "EXECUTE_RIVET_TRANSACTION", data: event.data.data, error: event.data?.error });
       window.postMessage({ ...res, type: res.type }, window.location.origin);
-      return true;
     } else if (event.data.type === 'SIGN_RIVET_MESSAGE') {
       let res = await chrome.runtime.sendMessage({ type: "SIGN_RIVET_MESSAGE", data: event.data.data });
       window.postMessage({ ...res, type: res.type }, window.location.origin);
-      return true;
+    } else if (event.data.type === 'SIMULATE_RIVET_TRANSACTION') {
+      let res = await chrome.runtime.sendMessage({ type: "SIMULATE_RIVET_TRANSACTION", data: event.data.data });
+      window.postMessage({ ...res, type: res.type }, window.location.origin);
     }
   }
   return true;
@@ -112,6 +113,26 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     })();
     return true;
   }
+
+  if (message.type === 'SIMULATE_RIVET_TRANSACTION_RES') {   
+    (async () => {
+      try {
+        let res = await chrome.runtime.sendMessage({ type: message.type, data: message.data });
+        window.postMessage({ type: "SIMULATE_RIVET_TRANSACTION_RES", data: res }, "*");
+        sendResponse(res);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error("Error in handling message:", error.message);
+          sendResponse({ success: false, error: error.message });
+        } else {
+          console.error("An unknown error occurred", error);
+          sendResponse({ success: false, error: "An unknown error occurred" });
+        }
+      }
+    })();
+    return true;
+  }
+
 
   if (message.type === 'SIGN_RIVET_MESSAGE_RES') {   
     (async () => {

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,4 +1,5 @@
 import "./Popup.css";
+import React from "react";
 import PredeployedAccounts from "../components/predeployedAccounts/predeployedAccounts";
 import DockerCommandGenerator from "../components/dockerCommand/dockerCommand";
 import RegisterRunningDocker from "../components/registerRunningDocker/registerRunningDocker";
@@ -20,7 +21,7 @@ export const Popup = () => {
 
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === "EXECUTE_RIVET_TRANSACTION") {
-      setTransactionData(message.data);
+      setTransactionData({data: message.data, error: message?.error});
       setSelectedComponent(Component.Accounts)
     }
     else if (message.type === "SIGN_RIVET_MESSAGE") {


### PR DESCRIPTION
### Description

Add simulation before execution .
Print an error message if the simulation fails.

<img width="338" alt="Capture d’écran 2024-06-14 à 15 51 27" src="https://github.com/0xSpaceShard/starknet-rivet/assets/56728586/8e22f715-b868-446e-9b5e-21aededadae7">

Disable confirm if error exists

<img width="329" alt="Capture d’écran 2024-06-14 à 15 52 07" src="https://github.com/0xSpaceShard/starknet-rivet/assets/56728586/e6585b58-827c-44f7-b2f0-b01743e6f568">

