### PR TITLE
fix: change  updateSelectedAccount so currentBalance wont be undefined

### DIFF
--- a/src/components/predeployedAccounts/predeployedAccounts.tsx
+++ b/src/components/predeployedAccounts/predeployedAccounts.tsx
@@ -81,8 +81,8 @@ export const PredeployedAccounts: React.FC = () => {
   const handleAccountClick = async (clickedAddress: string) => {
     const clickedAccount = accounts.find((account) => account.address === clickedAddress);
     if (clickedAccount) {
-      await updateSelectedAccount(clickedAccount);
       await fetchCurrentBalance(clickedAccount.address);
+      await updateSelectedAccount(clickedAccount);
       navigate(`/accounts/${clickedAccount.address}`);
     }
   };


### PR DESCRIPTION
## Motivation and Resolution

On the first connection, the balance might be undefined if we do `updateSelectedAccount` before fetching the balance.

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- ...

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code
- [x] Updated the tests
- [x] All tests are passing
